### PR TITLE
feat: check root project itself for pertains

### DIFF
--- a/src/pertain.ts
+++ b/src/pertain.ts
@@ -58,6 +58,7 @@ function pertain(rootDir: string, subject: string): Pertaining[] {
       ...dependencies,
       ...devDependencies
     });
+    allDependencyNames.push('./'); // rootDir too
     debug('%s allDependencyNames %s', rootDir, allDependencyNames);
     depSet = new ExplicitDependencySet(resolve, allDependencyNames);
     dependencySetCache.set(rootDir, depSet);


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

All dependencies of the root are checked, but the root itself is not checked.

* **What is the new behavior (if this is a feature change)?**

Adds the root directory itself to the list of dependencies to check for pertinance.

* **Other information**:

This is so the project itself can participate in its own plugin pipeline.