### PR TITLE
improvement: export resolverFactory

### DIFF
--- a/src/__tests__/resolverFactory.spec.ts
+++ b/src/__tests__/resolverFactory.spec.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import resolverFactory from '../resolverFactory';
+import { resolver as resolverFactory } from '../';
 
 describe('locally', () => {
   const base = path.resolve(__dirname, '../../');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { default } from './pertain';
+export { default as resolver } from './resolverFactory';


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Publishes the default resolver so other things can use it

* **What is the current behavior?** (You can also link to an open issue here)

Resolver is modular but internal


* **What is the new behavior (if this is a feature change)?**
```js
import pertain, { resolver } from 'pertain'

const resolve = resolver(context);

resolve('some-module') // yields its base dir
```


* **Other information**:
